### PR TITLE
feat: useDarkMode 훅 구현

### DIFF
--- a/docs/docs/hooks/useDarkMode.md
+++ b/docs/docs/hooks/useDarkMode.md
@@ -1,0 +1,64 @@
+# useDarkMode
+
+다크 모드 상태를 관리하는 커스텀 React Hook입니다.
+
+로컬 스토리지에 사용자 설정을 저장하고, 시스템 다크 모드 설정을 자동으로 감지하여 초기값을 설정합니다. 또한 HTML 문서에 `dark` 클래스를 자동으로 추가/제거하여 CSS와 연동할 수 있습니다.
+
+## 🔗 사용법
+
+```tsx
+const [darkMode, toggleDarkMode] = useDarkMode();
+```
+
+### 매개변수
+
+이 Hook은 매개변수를 받지 않습니다.
+
+### 반환값
+
+`[darkMode, toggleDarkMode]`
+
+| 인덱스 | 이름             | 타입         | 설명                           |
+| ------ | ---------------- | ------------ | ------------------------------ |
+| `0`    | `darkMode`       | `boolean`    | 현재 다크 모드 상태            |
+| `1`    | `toggleDarkMode` | `() => void` | 다크 모드 상태를 토글하는 함수 |
+
+## ✅ 예시
+
+```tsx
+import { useDarkMode } from './hooks/useDarkMode';
+
+function App() {
+  const [darkMode, toggleDarkMode] = useDarkMode();
+
+  return (
+    <div className={darkMode ? 'dark-theme' : 'light-theme'}>
+      <header>
+        <h1>My App</h1>
+        <button onClick={toggleDarkMode}>{darkMode ? '🌞 라이트 모드' : '🌙 다크 모드'}</button>
+      </header>
+      <main>
+        <p>현재 테마: {darkMode ? '다크' : '라이트'}</p>
+      </main>
+    </div>
+  );
+}
+```
+
+## 🎨 CSS 연동
+
+Hook이 자동으로 `html` 요소에 `dark` 클래스를 추가하므로, CSS에서 다크 모드 스타일을 쉽게 적용할 수 있습니다:
+
+```css
+/* 라이트 모드 (기본) */
+body {
+  background-color: white;
+  color: black;
+}
+
+/* 다크 모드 */
+html.dark body {
+  background-color: #1a1a1a;
+  color: white;
+}
+```

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,3 +1,4 @@
 export * from './libs/useBooleanState';
 export * from './libs/useArrayState';
 export * from './libs/useDebounce';
+export * from './libs/useDarkMode';

--- a/packages/hooks/src/libs/useDarkMode.spec.tsx
+++ b/packages/hooks/src/libs/useDarkMode.spec.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useDarkMode } from './useDarkMode';
+
+const LOCAL_STORAGE_KEY = 'darkMode';
+
+// 테스트용 컴포넌트
+function DarkModeTestComponent() {
+  const [darkMode, toggleDarkMode] = useDarkMode();
+
+  return (
+    <div>
+      <div>DarkMode: {darkMode ? 'true' : 'false'}</div>
+      <button onClick={toggleDarkMode}>Toggle</button>
+    </div>
+  );
+}
+
+describe('useDarkMode', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('초기 상태는 시스템 설정을 따른다 (localStorage 없을 때)', () => {
+    // 강제로 시스템 설정을 조작
+    window.matchMedia = jest.fn().mockReturnValue({
+      matches: true,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    });
+
+    render(<DarkModeTestComponent />);
+    expect(screen.getByText(/DarkMode: true/)).toBeInTheDocument();
+  });
+
+  test('localStorage에 저장된 값이 있을 경우 저장된 값을 따른다.', () => {
+    localStorage.setItem(LOCAL_STORAGE_KEY, 'false');
+    render(<DarkModeTestComponent />);
+    expect(screen.getByText(/DarkMode: false/)).toBeInTheDocument();
+  });
+
+  test('toggleDarkMode가 호출되면 상태와 localStorage의 값이 바뀐다.', () => {
+    render(<DarkModeTestComponent />);
+    const button = screen.getByText('Toggle');
+
+    expect(screen.getByText(/DarkMode: false|true/)).toBeInTheDocument();
+    const initial = screen.getByText(/DarkMode: (true|false)/).textContent;
+
+    fireEvent.click(button);
+
+    const toggled = screen.getByText(/DarkMode: (true|false)/).textContent;
+    expect(toggled).not.toBe(initial);
+
+    const stored = localStorage.getItem(LOCAL_STORAGE_KEY);
+    expect(stored).toBe(toggled?.split(': ')[1]);
+  });
+});

--- a/packages/hooks/src/libs/useDarkMode.ts
+++ b/packages/hooks/src/libs/useDarkMode.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * useDarkMode 훅은 다크 모드 상태를 관리합니다.
+ *
+ * @returns [darkMode, toggleDarkMode]
+ * - darkMode: 현재 다크 모드 상태 (boolean)
+ * - toggleDarkMode: 다크 모드 상태를 토글하는 함수
+ */
+type UseDarkModeReturn = [darkMode: boolean, toggleDarkMode: () => void];
+
+const LOCAL_STORAGE_KEY = 'darkMode';
+
+export function useDarkMode(): UseDarkModeReturn {
+  // 초기값을 localStorage에서 가져오거나, 시스템 설정에 따라 결정
+  const getInitialValue = () => {
+    const storedValue = localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (storedValue !== null) {
+      return storedValue === 'true';
+    }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  };
+
+  const [darkMode, setDarkMode] = useState(getInitialValue);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = (event: MediaQueryListEvent) => {
+      const userPreference = localStorage.getItem(LOCAL_STORAGE_KEY);
+      if (userPreference === null) {
+        setDarkMode(event.matches);
+      }
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', darkMode);
+  }, [darkMode]);
+
+  const toggleDarkMode = () => {
+    setDarkMode((prev) => {
+      const next = !prev;
+      localStorage.setItem(LOCAL_STORAGE_KEY, next.toString());
+      return next;
+    });
+  };
+
+  return [darkMode, toggleDarkMode];
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #34 

## 📝 훅 간단 사용 설명

> 어떤 훅인지 간단하게 설명해주세요! (docs 내용 기반)

다크 모드 상태를 관리하는 커스텀 React Hook입니다.
로컬 스토리지에 사용자 설정을 저장하고, 시스템 다크 모드 설정을 자동으로 감지하여 초기값을 설정합니다. 또한 HTML 문서에 `dark` 클래스를 자동으로 추가/제거하여 CSS와 연동할 수 있습니다.


```tsx
const [darkMode, toggleDarkMode] = useDarkMode();
```

### 🔥 로직 간단 설명 
- 사용자의 다크 모드 설정을 localStorage에 저장 및 불러오기
- 설정이 없을 경우 시스템 다크 모드(prefers-color-scheme)를 기본값으로 사용
- 상태 변화 시 <html>에 "dark" 클래스 자동 토글
- [darkMode, toggleDarkMode] 형태로 상태 및 전환 함수 반환

### 🙇‍♀️ 고민 사항 
dark 클래스를 토글 해주는 것이 사용자 입장에서는 매번 이 hook을 사용할 때마다 자동으로 다크 모드 스타일이 적용되어 편리하지만, hook 자체 내에서 DOM 조작을 하게 된다는 점에서 저 토글의 유용성이 얼마나 될까 ,,, 고민이 됩니다! 사용하는 측에서 DOM 조작을 관리하고 싶을 수도 있다고 생각되어 이 부분 어떻게 생각하시는지 궁금합니다 !


### 스크린샷 (선택)

https://github.com/user-attachments/assets/6d499133-886b-445a-85f0-2d5f642a9820



