### PR TITLE
useMeasure 훅

### DIFF
--- a/docs/docs/hooks/useMeasure.md
+++ b/docs/docs/hooks/useMeasure.md
@@ -11,7 +11,7 @@
 ## 🔗 사용법
 
 ```tsx
-const [ref, size] = useMeasure<HTMLDivElement>();
+const { ref, size } = useMeasure<HTMLDivElement>();
 ```
 
 ---
@@ -24,12 +24,12 @@ const [ref, size] = useMeasure<HTMLDivElement>();
 
 ## 🔁 반환값
 
-`[ref, size]`
+`{ref, size}`
 
-| 인덱스 | 이름   | 타입                                | 설명                                                        |
-| ------ | ------ | ----------------------------------- | ----------------------------------------------------------- |
-| `0`    | `ref`  | `RefObject<T>`                      | 크기를 측정할 DOM 요소에 연결할 `ref` 객체                  |
-| `1`    | `size` | `{ width: number; height: number }` | 측정된 요소의 현재 크기. `ref`가 없을 경우 window 크기 반환 |
+| 키     | 타입                                | 설명                                                        |
+| ------ | ----------------------------------- | ----------------------------------------------------------- |
+| `ref`  | `RefObject<T>`                      | 크기를 측정할 DOM 요소에 연결할 `ref` 객체                  |
+| `size` | `{ width: number; height: number }` | 측정된 요소의 현재 크기. `ref`가 없을 경우 window 크기 반환 |
 
 ---
 
@@ -40,7 +40,7 @@ const [ref, size] = useMeasure<HTMLDivElement>();
 - 예시: `HTMLDivElement`, `HTMLTextAreaElement`, `HTMLCanvasElement` 등
 
 ```tsx
-const [ref, size] = useMeasure<HTMLTextAreaElement>();
+const { ref, size } = useMeasure<HTMLTextAreaElement>();
 ```
 
 ---
@@ -51,7 +51,7 @@ const [ref, size] = useMeasure<HTMLTextAreaElement>();
 
 ```tsx
 function Component() {
-  const [ref, size] = useMeasure<HTMLDivElement>();
+  const { ref, size } = useMeasure<HTMLDivElement>();
 
   return (
     <div ref={ref} style={{ resize: 'both', overflow: 'auto' }}>
@@ -66,7 +66,7 @@ function Component() {
 
 ```tsx
 function FullscreenLayout() {
-  const [, size] = useMeasure();
+  const { size } = useMeasure();
 
   return (
     <div>

--- a/docs/docs/hooks/useMeasure.md
+++ b/docs/docs/hooks/useMeasure.md
@@ -1,0 +1,121 @@
+# `useMeasure`
+
+`useMeasure`는 DOM 요소의 크기(`width`, `height`)를 실시간으로 측정하고, 해당 요소의 크기가 변경될 때마다 자동으로 업데이트되는 커스텀 React Hook입니다.
+
+- `ResizeObserver`를 이용해 요소의 크기 변화를 추적합니다.
+- `ref`를 연결하지 않은 경우, `window.innerWidth`와 `window.innerHeight`를 사용하여 뷰포트 크기를 기본값으로 제공합니다.
+- `크기가 변경되지 않은 경우에는` 불필요한 상태 업데이트를 방지합니다.
+
+---
+
+## 🔗 사용법
+
+```tsx
+const [ref, size] = useMeasure<HTMLDivElement>();
+```
+
+---
+
+## 📥 매개변수
+
+해당 훅은 별도의 매개변수를 받지 않습니다. 대신 **반환된 `ref`를 특정 DOM 요소에 연결**해 사용하는 방식입니다.
+
+---
+
+## 🔁 반환값
+
+`[ref, size]`
+
+| 인덱스 | 이름   | 타입                                | 설명                                                        |
+| ------ | ------ | ----------------------------------- | ----------------------------------------------------------- |
+| `0`    | `ref`  | `RefObject<T>`                      | 크기를 측정할 DOM 요소에 연결할 `ref` 객체                  |
+| `1`    | `size` | `{ width: number; height: number }` | 측정된 요소의 현재 크기. `ref`가 없을 경우 window 크기 반환 |
+
+---
+
+## 🧩 제네릭 타입
+
+`useMeasure<T>()` 형태로 사용할 수 있으며, `T`는 `HTMLElement`를 확장한 타입입니다.
+
+- 예시: `HTMLDivElement`, `HTMLTextAreaElement`, `HTMLCanvasElement` 등
+
+```tsx
+const [ref, size] = useMeasure<HTMLTextAreaElement>();
+```
+
+---
+
+## ✅ 예시
+
+### 기본 사용
+
+```tsx
+function Component() {
+  const [ref, size] = useMeasure<HTMLDivElement>();
+
+  return (
+    <div ref={ref} style={{ resize: 'both', overflow: 'auto' }}>
+      <p>너비: {size.width}px</p>
+      <p>높이: {size.height}px</p>
+    </div>
+  );
+}
+```
+
+### `ref`를 연결하지 않은 경우 (fallback으로 window 크기 사용)
+
+```tsx
+function FullscreenLayout() {
+  const [, size] = useMeasure();
+
+  return (
+    <div>
+      현재 화면 크기: {size.width} x {size.height}
+    </div>
+  );
+}
+```
+
+---
+
+## 🧠 작동 방식
+
+1. `ref.current`가 존재하면 `ResizeObserver`를 등록하여 요소의 크기 변화를 감지합니다.
+2. `ref.current`가 `null`일 경우, `window.innerWidth` 및 `innerHeight`를 초기값으로 사용하고,
+
+   `resize` 이벤트를 통해 크기 변화를 추적합니다.
+
+3. 크기 값이 변하지 않은 경우에는 `setState`를 호출하지 않아 불필요한 리렌더링을 방지합니다.
+
+---
+
+## 💡 만약 이 훅이 없다면?
+
+직접 `ResizeObserver` 또는 `window.addEventListener('resize')`를 사용해 다음과 같이 처리해야 합니다:
+
+```tsx
+function ManualMeasure() {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    if (!ref.current) return;
+
+    const observer = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect;
+      setSize({ width, height });
+    });
+
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={ref}>
+      크기: {size.width} x {size.height}
+    </div>
+  );
+}
+```
+
+`useMeasure`를 사용하면 위 작업을 훨씬 간단하게 추상화하여 사용할 수 있습니다.

--- a/packages/hooks/src/libs/useMeasure.spec.tsx
+++ b/packages/hooks/src/libs/useMeasure.spec.tsx
@@ -7,7 +7,7 @@ describe('useMeasure 훅', () => {
   it('ref를 사용하지 않을 경우 window 크기를 반환해야 한다.', () => {
     const { result } = renderHook(() => useMeasure());
 
-    const [, size] = result.current;
+    const { size } = result.current;
 
     expect(size.width).toBe(window.innerWidth);
     expect(size.height).toBe(window.innerHeight);
@@ -16,7 +16,7 @@ describe('useMeasure 훅', () => {
   it('ref를 div에 연결했을 때 ref가 잘 잡히고, size도 잘 나와야한다.', () => {
     const { result } = renderHook(() => useMeasure<HTMLDivElement>());
 
-    const [ref] = result.current;
+    const { ref } = result.current;
 
     render(
       <div ref={ref} style={{ width: '500px' }}>

--- a/packages/hooks/src/libs/useMeasure.spec.tsx
+++ b/packages/hooks/src/libs/useMeasure.spec.tsx
@@ -1,0 +1,28 @@
+// useMeasure.test.tsx
+import { renderHook } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import useMeasure from './useMeasure';
+
+describe('useMeasure 훅', () => {
+  it('ref를 사용하지 않을 경우 window 크기를 반환해야 한다.', () => {
+    const { result } = renderHook(() => useMeasure());
+
+    const [, size] = result.current;
+
+    expect(size.width).toBe(window.innerWidth);
+    expect(size.height).toBe(window.innerHeight);
+  });
+
+  it('ref를 div에 연결했을 때 ref가 잘 잡히고, size도 잘 나와야한다.', () => {
+    const { result } = renderHook(() => useMeasure<HTMLDivElement>());
+
+    const [ref] = result.current;
+
+    render(
+      <div ref={ref} style={{ width: '500px' }}>
+        크기 측정
+      </div>
+    );
+    expect((ref.current as HTMLDivElement).textContent).toBe('크기 측정');
+  });
+});

--- a/packages/hooks/src/libs/useMeasure.ts
+++ b/packages/hooks/src/libs/useMeasure.ts
@@ -1,0 +1,64 @@
+import { RefObject, useEffect, useRef, useState } from 'react';
+
+type useMeasureReturn<T> = [RefObject<T>, { width: number; height: number }];
+
+/**
+ * `useMeasure` 훅은 요소의 크기(`width`, `height`)를 측정하고,
+ * 해당 요소의 크기가 변경될 때마다 자동으로 업데이트되는 값을 제공합니다.
+ *
+ * - `ref`를 연결한 DOM 요소의 크기를 `ResizeObserver`를 통해 감지합니다.
+ * - `ref를 사용하지 않는 경우엔, `window.innerWidth`와 `window.innerHeight`를 사용하여
+ *   뷰포트 크기를 반환하며, 윈도우 리사이즈 이벤트를 구독합니다.
+ * - 크기가 변경되지 않은 경우에는 불필요한 상태 업데이트를 방지합니다.
+ *
+ * @template T - 크기를 측정할 HTML 요소 타입 (예: HTMLDivElement, HTMLTextAreaElement 등)
+ *
+ * @returns {[RefObject<T>, { width: number; height: number }]}
+ * - `[0]`: 크기를 측정할 DOM 요소에 연결할 `ref` 객체
+ * - `[1]`: 해당 요소 또는 윈도우의 현재 `{ width, height }` 정보
+ *
+ * @example
+ * const [ref, size] = useMeasure<HTMLDivElement>();
+ * return <div ref={ref}>너비: {size.width}px</div>;
+ *
+ * @example
+ * // ref를 연결하지 않으면 window 크기를 추적합니다.
+ * const [, viewport] = useMeasure();
+ * console.log(viewport.width); // window.innerWidth
+ */
+
+const useMeasure = <T extends HTMLElement>(): useMeasureReturn<T> => {
+  const [state, setState] = useState({ width: 0, height: 0 });
+  const ref = useRef<T | null>(null);
+
+  useEffect(() => {
+    let observer: ResizeObserver | null = null;
+
+    const updateWindowSize = () => {
+      setState({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+
+    if (ref.current) {
+      observer = new ResizeObserver(([entry]) => {
+        const { width, height } = entry.contentRect;
+        setState((prev) => (prev.width === width && prev.height === height ? prev : { width, height }));
+      });
+      observer.observe(ref.current);
+    } else {
+      updateWindowSize();
+      window.addEventListener('resize', updateWindowSize);
+    }
+
+    return () => {
+      if (observer) observer.disconnect();
+      else window.removeEventListener('resize', updateWindowSize);
+    };
+  }, []);
+
+  return [ref, state];
+};
+
+export default useMeasure;

--- a/packages/hooks/src/libs/useMeasure.ts
+++ b/packages/hooks/src/libs/useMeasure.ts
@@ -1,6 +1,6 @@
 import { RefObject, useEffect, useRef, useState } from 'react';
 
-type useMeasureReturn<T> = [RefObject<T>, { width: number; height: number }];
+type useMeasureReturn<T> = { ref: RefObject<T>; size: { width: number; height: number } };
 
 /**
  * `useMeasure` 훅은 요소의 크기(`width`, `height`)를 측정하고,
@@ -13,18 +13,18 @@ type useMeasureReturn<T> = [RefObject<T>, { width: number; height: number }];
  *
  * @template T - 크기를 측정할 HTML 요소 타입 (예: HTMLDivElement, HTMLTextAreaElement 등)
  *
- * @returns {[RefObject<T>, { width: number; height: number }]}
- * - `[0]`: 크기를 측정할 DOM 요소에 연결할 `ref` 객체
- * - `[1]`: 해당 요소 또는 윈도우의 현재 `{ width, height }` 정보
+ * @returns {{ref:RefObject<T>, size:{ width: number; height: number }}}
+ * - `ref`: 크기를 측정할 DOM 요소에 연결할 `ref` 객체
+ * - `size`: 해당 요소 또는 윈도우의 현재 `{ width, height }` 정보
  *
  * @example
- * const [ref, size] = useMeasure<HTMLDivElement>();
+ * const {ref, size} = useMeasure<HTMLDivElement>();
  * return <div ref={ref}>너비: {size.width}px</div>;
  *
  * @example
  * // ref를 연결하지 않으면 window 크기를 추적합니다.
- * const [, viewport] = useMeasure();
- * console.log(viewport.width); // window.innerWidth
+ * const {size} = useMeasure();
+ * console.log(size.width); // window.innerWidth
  */
 
 const useMeasure = <T extends HTMLElement>(): useMeasureReturn<T> => {
@@ -58,7 +58,7 @@ const useMeasure = <T extends HTMLElement>(): useMeasureReturn<T> => {
     };
   }, []);
 
-  return [ref, state];
+  return { ref, size: state };
 };
 
 export default useMeasure;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #36 

## 📝 훅 간단 사용 설명

> `useMeasure`는 DOM 요소의 크기(`width`, `height`)를 실시간으로 측정하고, 해당 요소의 크기가 변경될 때마다 자동으로 업데이트되는 커스텀 React Hook입니다.
ref를 할당하지 않으면, 기본 size 값은 window 객체가 됩니다!

### 스크린샷 (선택)
- 전체 window 객체 크기

https://github.com/user-attachments/assets/f312395b-b2ee-4072-8dea-ad30d17500fb

- 내부 Element 요소 크기

https://github.com/user-attachments/assets/f9f80fc7-c0a0-4aa4-8c52-82cf0023970b



