### PR TITLE
feat : useLockBodyScroll

### DIFF
--- a/docs/docs/hooks/useLockBodyScroll.md
+++ b/docs/docs/hooks/useLockBodyScroll.md
@@ -1,0 +1,74 @@
+# `useLockBodyScroll`
+
+- 모달 등 **컴포넌트가 마운트된 동안 `document.body` 스크롤을 잠그고**, 언마운트 시 **원래 상태로 복원**하는 커스텀 Hook입니다.
+- 여러 모달이 동시에 떠 있어도 **마지막 하나가 닫힐 때까진 잠금 유지**되도록 카운팅합니다.
+
+---
+
+## ✨ 특징
+
+- 마운트 시 `body.style.overflow = 'hidden'` / 언마운트 시 **원래 값으로 복원**
+- **다중 모달 안전**: 중첩 사용 시 마지막 언마운트에서만 복원
+- 훅 네이밍 **명시적**: 훅 호출만으로 “이 컴포넌트가 떠 있는 동안 잠금” 의도 표현
+
+---
+
+## 🔗 시그니처
+
+```tsx
+useLockBodyScroll(): void
+```
+
+인자·반환값 없음. (컴포넌트 내부 (ex. 모달)에서 호출하면 끝)
+
+---
+
+## 🧩 사용법
+
+```tsx
+import { useLockBodyScroll } from 'hookdle';
+
+function MyModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  if (!open) return null;
+  useLockBodyScroll(); // 모달이 떠 있는 동안만 body 스크롤 잠금
+
+  return (
+    <div className="modal">
+      <h2>모달</h2>
+      <button onClick={onClose}>닫기</button>
+    </div>
+  );
+}
+```
+
+**다중 모달 예시**
+
+```tsx
+// 두 모달 모두 내부에서 useLockBodyScroll() 호출
+{openA && <ModalA />}
+{openB && <ModalB />}
+```
+
+A 열기 → B 열기 → B 닫기 → **(여전히 잠금)** → A 닫기 → 복원
+
+---
+
+## 💡 이 훅이 없으면?
+
+모달마다 `overflow`를 직접 설정/복원하고, 다중 모달 충돌도 직접 처리해야 합니다.
+
+```jsx
+useEffect(() => {
+  let savedOverflow = '';
+
+  if (open) {
+    savedOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+  }
+
+  return () => {
+    // 이 시점에서는 effect 실행 시점의 savedOverflow를 기억하고 있음
+    document.body.style.overflow = savedOverflow || 'visible';
+  };
+}, [open]);
+```

--- a/packages/hooks/src/libs/useLockBodyScroll.spec.tsx
+++ b/packages/hooks/src/libs/useLockBodyScroll.spec.tsx
@@ -1,0 +1,44 @@
+// useLockBodyScroll.test.tsx
+import { renderHook } from '@testing-library/react';
+import { useLockBodyScroll } from './useLockBodyScroll';
+
+describe('useLockBodyScroll 훅', () => {
+  it('useLockBodyScroll 훅을 사용하는 컴포넌트가 마운트 시 body overflow는 hidden으로 변경된다.', () => {
+    document.body.style.overflow = 'auto';
+
+    const { unmount } = renderHook(() => useLockBodyScroll());
+
+    expect(document.body.style.overflow).toBe('hidden');
+
+    unmount();
+  });
+
+  it('useLockBodyScroll 훅을 사용하는 컴포넌트가 언마운트 시 body overflow는 기존으로 돌아온다.', () => {
+    document.body.style.overflow = 'auto';
+
+    const { unmount } = renderHook(() => useLockBodyScroll());
+
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+
+    expect(document.body.style.overflow).toBe('auto');
+  });
+
+  test('다중 마운트 테스트: 마지막 언마운트 전까지는 body overflow는 유지된다.', async () => {
+    document.body.style.overflow = 'auto';
+
+    const testA = renderHook(() => useLockBodyScroll());
+    expect(document.body.style.overflow).toBe('hidden');
+
+    const testB = renderHook(() => useLockBodyScroll());
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // testA 컴포넌트 언마운트
+    testA.unmount();
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // testB 컴포넌트 언마운트
+    testB.unmount();
+    expect(document.body.style.overflow).toBe('auto');
+  });
+});

--- a/packages/hooks/src/libs/useLockBodyScroll.ts
+++ b/packages/hooks/src/libs/useLockBodyScroll.ts
@@ -1,0 +1,31 @@
+import { useLayoutEffect } from 'react';
+
+let lockCount = 0;
+let savedOverflow: string | null = null;
+
+/**
+ * body 스크롤 잠금 훅
+ * - 마운트 시 body overflow를 'hidden'으로 변경
+ * - 언마운트 시 원래 상태 복원
+ * - 다중 모달 지원
+ *
+ * @example
+ * useLockBodyScroll(); // 모달 내부에서 호출 시 모달 열리는 동안 스크롤 잠금
+ */
+export const useLockBodyScroll = (): void => {
+  useLayoutEffect(() => {
+    if (lockCount === 0) {
+      savedOverflow = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+    }
+    lockCount += 1;
+
+    return () => {
+      lockCount -= 1;
+      if (lockCount === 0) {
+        document.body.style.overflow = savedOverflow ?? 'auto';
+        savedOverflow = null;
+      }
+    };
+  }, []);
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #46 

## 📝 훅 간단 사용 설명

>`useLockBodyScroll`

- 모달 등 **컴포넌트가 마운트된 동안 `document.body` 스크롤을 잠그고**, 언마운트 시 **원래 상태로 복원**하는 커스텀 Hook입니다.
- 여러 모달이 동시에 떠 있어도 **마지막 하나가 닫힐 때까진 잠금 유지**되도록 카운팅합니다.


### 스크린샷 (선택)
**단일 모달 테스트**
https://github.com/user-attachments/assets/08526c06-54ef-4310-b12c-6474c0230e37

**다중 모달 테스트**

https://github.com/user-attachments/assets/95559ab1-b8cb-413f-84a3-49934cfc0714

