### PR TITLE
feat: useEventListener

### DIFF
--- a/docs/docs/hooks/useEventListener.md
+++ b/docs/docs/hooks/useEventListener.md
@@ -1,0 +1,92 @@
+# useEventListener
+
+`useEventListener`는 지정한 이벤트 타입에 대해 타겟 요소에 안전하게 이벤트 리스너를 등록·해제하는 커스텀 React 훅입니다.
+
+DOM 요소, `window`, `document`, `MediaQueryList` 등 다양한 이벤트 타겟에 대응하며, 최신 콜백 유지와 자동 정리까지 처리합니다.
+
+## 🔗 사용법
+
+```tsx
+useEventListener(target, type, listener, options);
+```
+
+### 매개변수
+
+| 이름       | 타입                                          | 설명                                                  |
+| ---------- | --------------------------------------------- | ----------------------------------------------------- |
+| `target`   | `RefObject<EventTarget>` \| `EventTarget`     | 이벤트를 등록할 대상 (`ref` 객체 또는 직접 지정 가능) |
+| `type`     | `string`                                      | 이벤트 타입 (예: `'click'`, `'resize'`, `'keydown'`)  |
+| `listener` | `(e: Event) => void`                          | 이벤트 발생 시 실행될 콜백 함수                       |
+| `options`  | `boolean \| AddEventListenerOptions` _(선택)_ | 이벤트 등록 옵션 (`capture`, `once`, `passive` 등)    |
+
+## ✅ 예시
+
+### 1. window 리사이즈 이벤트
+
+```tsx
+import React, { useState } from 'react';
+import { useEventListener } from './useEventListener';
+
+function WindowSizeLogger() {
+  const [size, setSize] = useState({ width: window.innerWidth, height: window.innerHeight });
+
+  useEventListener(window, 'resize', () => {
+    setSize({ width: window.innerWidth, height: window.innerHeight });
+  });
+
+  return (
+    <div>
+      <p>가로: {size.width}px</p>
+      <p>세로: {size.height}px</p>
+    </div>
+  );
+}
+```
+
+### 2. 특정 DOM 요소 클릭 감지
+
+```tsx
+import React, { useRef, useState } from 'react';
+import { useEventListener } from './useEventListener';
+
+function ClickCounter() {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [count, setCount] = useState(0);
+
+  useEventListener(buttonRef, 'click', () => {
+    setCount((prev) => prev + 1);
+  });
+
+  return (
+    <div>
+      <button ref={buttonRef}>클릭 횟수: {count}</button>
+    </div>
+  );
+}
+```
+
+### 3. MediaQueryList 이벤트 감지
+
+```tsx
+import React, { useState } from 'react';
+import { useEventListener } from './useEventListener';
+
+function DarkModeDetector() {
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  const [isDark, setIsDark] = useState(mediaQuery.matches);
+
+  useEventListener(mediaQuery, 'change', (e: MediaQueryListEvent) => {
+    setIsDark(e.matches);
+  });
+
+  return <div>현재 모드: {isDark ? '다크 모드' : '라이트 모드'}</div>;
+}
+```
+
+## 📋 주의사항
+
+- listener 함수는 내부에서 최신 참조를 유지하므로, 매 렌더마다 이벤트를 재등록할 필요가 없습니다.
+- options 객체를 매번 새로 만들면 재등록이 발생하므로, 필요한 경우 useMemo로 안정화하는 것이 좋습니다.
+- target이 null인 경우(예: 조건부 렌더링 시), 이벤트는 등록되지 않습니다.
+- cleanup은 훅 내부에서 자동으로 처리되므로 별도 해제가 필요 없습니다.
+- ref 객체를 사용할 때는 ref.current가 유효한 시점에만 이벤트가 등록됩니다.

--- a/packages/hooks/src/libs/useEventListener.spec.ts
+++ b/packages/hooks/src/libs/useEventListener.spec.ts
@@ -1,0 +1,52 @@
+import { renderHook } from '@testing-library/react';
+import { useEventListener } from './useEventListener';
+
+describe('useEventListener', () => {
+  it('window 이벤트를 등록하고 해제한다', () => {
+    const mockListener = jest.fn();
+
+    const { unmount } = renderHook(() => useEventListener(window, 'resize', mockListener));
+
+    // 이벤트 발생
+    window.dispatchEvent(new Event('resize'));
+    expect(mockListener).toHaveBeenCalledTimes(1);
+
+    // 언마운트 후 이벤트 발생
+    unmount();
+    window.dispatchEvent(new Event('resize'));
+    expect(mockListener).toHaveBeenCalledTimes(1); // 더 이상 호출 안 됨
+  });
+
+  it('ref를 사용하여 HTMLElement 이벤트를 등록한다', () => {
+    const mockListener = jest.fn();
+
+    // 가짜 DOM 요소 생성
+    const div = document.createElement('div');
+    const ref = { current: div };
+
+    renderHook(() => useEventListener(ref, 'click', mockListener));
+
+    div.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(mockListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('listener 변경 시 최신 콜백이 호출된다', () => {
+    const mockListener1 = jest.fn();
+    const mockListener2 = jest.fn();
+
+    const { rerender } = renderHook(({ listener }) => useEventListener(window, 'resize', listener), {
+      initialProps: { listener: mockListener1 },
+    });
+
+    // 첫 번째 리스너 호출
+    window.dispatchEvent(new Event('resize'));
+    expect(mockListener1).toHaveBeenCalledTimes(1);
+
+    // 리스너 변경
+    rerender({ listener: mockListener2 });
+    window.dispatchEvent(new Event('resize'));
+
+    expect(mockListener1).toHaveBeenCalledTimes(1); // 더 이상 호출 안 됨
+    expect(mockListener2).toHaveBeenCalledTimes(1); // 새로운 리스너 호출됨
+  });
+});

--- a/packages/hooks/src/libs/useEventListener.ts
+++ b/packages/hooks/src/libs/useEventListener.ts
@@ -36,6 +36,55 @@ export function useEventListener(
   options?: EventListenerOptions
 ): void;
 
+/**
+ * 다양한 이벤트 타겟(Window, Document, HTMLElement, MediaQueryList 등)에
+ * 이벤트 리스너를 등록하고, 컴포넌트 언마운트 시 자동으로 해제하는 React 훅입니다.
+ *
+ * 이 훅은 이벤트 리스너의 등록과 해제를 자동으로 관리하므로,
+ * 직접 `addEventListener`/`removeEventListener`를 호출할 필요가 없습니다.
+ *
+ * @template K 주어진 타겟의 이벤트 맵에서 이벤트 타입 키 (예: `'click'`, `'resize'`, `'keydown'` 등)
+ *
+ * @param target - 이벤트 리스너를 등록할 대상
+ *   - `Window` 또는 `RefObject<Window>`
+ *   - `Document` 또는 `RefObject<Document>`
+ *   - `HTMLElement` 또는 `RefObject<HTMLElement>`
+ *   - `MediaQueryList` 또는 `RefObject<MediaQueryList>`
+ *   - 일반 `EventTarget` 또는 `RefObject<EventTarget>`
+ *
+ * @param type - 수신할 이벤트 타입 이름 (예: `'click'`, `'resize'`, `'keydown'`)
+ *
+ * @param listener - 이벤트 발생 시 호출될 콜백 함수
+ *   - 이벤트 객체를 인자로 받으며, 타입은 `target`에 따라 자동으로 추론됩니다.
+ *
+ * @param [options=false] - 이벤트 리스너 옵션
+ *   - `boolean`(캡처 여부) 또는 `AddEventListenerOptions` 객체
+ *
+ * @example
+ * ```tsx
+ * // window 리사이즈 이벤트 수신
+ * useEventListener(window, 'resize', (e) => {
+ *   console.log('윈도우 크기 변경', e);
+ * });
+ *
+ * // 버튼 클릭 이벤트 수신 (ref 사용)
+ * const buttonRef = useRef<HTMLButtonElement>(null);
+ * useEventListener(buttonRef, 'click', (e) => {
+ *   console.log('버튼 클릭', e);
+ * });
+ *
+ * // 미디어 쿼리 변경 이벤트 수신
+ * const mql = window.matchMedia('(max-width: 600px)');
+ * useEventListener(mql, 'change', (e) => {
+ *   console.log('미디어 쿼리 매치 여부:', e.matches);
+ * });
+ * ```
+ *
+ * @remarks
+ * - `RefObject`를 전달하면 `.current`에 이벤트 리스너가 등록됩니다.
+ * - 내부적으로 `listener` 참조를 안정적으로 유지하므로, 인라인 함수 전달 시에도 안전합니다.
+ * - 의존성(`target`, `type`, `options`)이 변경되면 기존 리스너를 제거하고 새로 등록합니다.
+ */
 export function useEventListener(
   target: RefObject<EventTargetLike> | EventTargetLike,
   type: string,

--- a/packages/hooks/src/libs/useEventListener.ts
+++ b/packages/hooks/src/libs/useEventListener.ts
@@ -103,9 +103,11 @@ export function useEventListener(
     const targetEl = isRefObject<EventTargetLike>(target) ? target.current : target;
     if (!targetEl || !targetEl.addEventListener) return;
 
-    targetEl.addEventListener(type, listenerRef.current, options);
+    const stable = (e: Event) => listenerRef.current(e);
+
+    targetEl.addEventListener(type, stable, options);
     return () => {
-      targetEl.removeEventListener(type, listenerRef.current, options);
+      targetEl.removeEventListener(type, stable, options);
     };
   }, [target, type, options]);
 }

--- a/packages/hooks/src/libs/useEventListener.ts
+++ b/packages/hooks/src/libs/useEventListener.ts
@@ -1,0 +1,62 @@
+import { RefObject, useEffect, useRef } from 'react';
+
+type EventTargetLike = Window | Document | HTMLElement | MediaQueryList | EventTarget;
+type EventListenerOptions = boolean | AddEventListenerOptions;
+
+const isRefObject = <T>(obj: unknown): obj is RefObject<T> => obj && typeof obj === 'object' && 'current' in obj;
+
+export function useEventListener<K extends keyof WindowEventMap>(
+  target: RefObject<Window> | Window,
+  type: K,
+  listener: (e: WindowEventMap[K]) => void,
+  options?: EventListenerOptions
+): void;
+export function useEventListener<K extends keyof DocumentEventMap>(
+  target: RefObject<Document> | Document,
+  type: K,
+  listener: (e: DocumentEventMap[K]) => void,
+  options?: EventListenerOptions
+): void;
+export function useEventListener<K extends keyof HTMLElementEventMap>(
+  target: RefObject<HTMLElement> | HTMLElement,
+  type: K,
+  listener: (e: HTMLElementEventMap[K]) => void,
+  options?: EventListenerOptions
+): void;
+export function useEventListener<K extends keyof MediaQueryListEventMap>(
+  target: RefObject<MediaQueryList> | MediaQueryList,
+  type: K,
+  listener: (e: MediaQueryListEventMap[K]) => void,
+  options?: EventListenerOptions
+): void;
+export function useEventListener(
+  target: RefObject<EventTarget> | EventTarget,
+  type: string,
+  listener: (e: Event) => void,
+  options?: EventListenerOptions
+): void;
+
+export function useEventListener(
+  target: RefObject<EventTargetLike> | EventTargetLike,
+  type: string,
+  listener: (e: Event) => void,
+  options: EventListenerOptions = false
+) {
+  const listenerRef = useRef(listener);
+
+  useEffect(() => {
+    listenerRef.current = listener;
+  }, [listener]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const targetEl = isRefObject<EventTargetLike>(target) ? target.current : target;
+    if (!targetEl || !targetEl.addEventListener) return;
+
+    targetEl.addEventListener(type, listenerRef.current, options);
+    return () => {
+      targetEl.removeEventListener(type, listenerRef.current, options);
+    };
+  }, [target, type, options]);
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

https://github.com/woowacourse-study/2025-fe-hookdle/issues/50

## 📝 훅 간단 사용 설명

- useEventListener는 지정한 이벤트 타입에 대해 타겟 요소에 안전하게 이벤트 리스너를 등록·해제하는 커스텀 React 훅입니다.
- DOM 요소, window, document, MediaQueryList 등 다양한 이벤트 타겟에 대응하며, 최신 콜백 유지와 자동 정리까지 처리합니다.

### 스크린샷 (선택)
